### PR TITLE
Run app container alongside external MySQL service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+frontend/node_modules
+backend.node/node_modules
+.git
+.gitignore
+npm-debug.log
+Dockerfile*
+**/dist
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Dockerfile for combined backend and frontend service
+FROM node:18-slim AS base
+
+WORKDIR /app
+
+# Install backend dependencies
+COPY backend.node/package*.json backend.node/
+RUN cd backend.node \
+    && npm install --production
+
+# Install frontend dependencies
+COPY frontend/package*.json frontend/
+RUN cd frontend \
+    && npm install
+
+# Copy application source
+COPY backend.node backend.node
+COPY frontend frontend
+
+# Build frontend for production
+RUN cd frontend \
+    && npm run build
+
+# Install a lightweight static server for the built frontend
+RUN npm install -g serve@14
+
+ENV FRONTEND_PORT=4173
+
+EXPOSE 5001 4173
+
+CMD ["sh", "-c", "node backend.node/server.js & exec serve -s frontend/dist -l \"${FRONTEND_PORT:-4173}\""]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # Capstone Project
- CSCI6806.V1 Computer Science Graduate Capstone Project 
+ CSCI6806.V1 Computer Science Graduate Capstone Project
+
+## Docker Setup
+
+This repository includes a Docker-based workflow that runs the backend API and the built frontend with a single command.
+
+### Prerequisites
+
+- Docker
+- Docker Compose v2
+
+### Running the Stack
+
+1. Build and start the service in the background:
+
+   ```bash
+   docker compose up --build -d
+   ```
+
+2. Access the applications:
+
+   - Backend API: http://localhost:5001
+   - Frontend UI: http://localhost:4173
+
+Environment variables for the backend are stored in `backend.node/.env`. Update this file if you need to target a different database host or change credentials. The Docker setup expects your MySQL instance to already be running and reachable at the host defined in that file.

--- a/backend.node/.env
+++ b/backend.node/.env
@@ -1,6 +1,6 @@
-PORT = 5001
-DB_HOST='localhost'
-DB_NAME='clinic'
-DB_PASSWORD=
-DB_USER='root'
-JWT_SECRET = '5d6e08669701497262eb57c4374f5d852d1552643f3b0cd5713b315ca24cf8b5'
+PORT=5001
+DB_HOST=128.199.31.100
+DB_NAME=clinic
+DB_PASSWORD=clinic1122
+DB_USER=clinicuser
+JWT_SECRET=super secret secret token jwt

--- a/backend.node/.gitignore
+++ b/backend.node/.gitignore
@@ -5,10 +5,6 @@
 /node_modules
 /.pnp
 .pnp.js
-./env
-
-
-# testing
 /coverage
 
 # production
@@ -16,10 +12,6 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/backend.node/server.js
+++ b/backend.node/server.js
@@ -26,6 +26,7 @@ const port = process.env.PORT || 5001;
 const allowedOrigins = [
   'https://azadzamani.github.io', // GitHub Pages frontend
   'http://localhost:3000',        // Local development frontend
+  'http://localhost:4173',        // Docker/Vite development frontend
 ];
 
 const corsOptions = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    ports:
+      - "5001:5001"
+      - "4173:4173"
+    env_file:
+      - backend.node/.env
+    environment:
+      - FRONTEND_PORT=4173
+      - NODE_ENV=production
+    restart: unless-stopped

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,12 +13,6 @@
 
 # misc
 .DS_Store
-.env
-.env.production
-.env.local
-.env.development
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
- update the Docker image to launch the backend and serve the built frontend without a helper script
- simplify docker-compose to run only the application container while sourcing environment values from the committed .env file
- keep environment files unignored and refresh documentation for the external MySQL workflow

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e01b5942148322801e0ad28d5aaceb