### PR TITLE
Update Node tooling for production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for combined backend and frontend service
-FROM node:18-slim AS base
+FROM node:20-slim AS base
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build: .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "start": "npm run dev",
     "dev": "vite",


### PR DESCRIPTION
## Summary
- upgrade the runtime image to Node 20 so the Vite build runs under a supported version
- declare the frontend package as an ES module to keep the Vite config compatible with the newer toolchain
- tidy the compose file header to silence the obsolete version warning

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_b_68e022f0d6f08322b43c23ce7f6656a3