### PR TITLE
Bundle MariaDB server into application container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Docker Setup
 
-This repository includes a Docker-based workflow that runs the backend API and the built frontend with a single command.
+This repository includes a Docker-based workflow that runs the backend API, a bundled MySQL-compatible database, and the built frontend with a single command.
 
 ### Prerequisites
 
@@ -23,4 +23,17 @@ This repository includes a Docker-based workflow that runs the backend API and t
    - Backend API: http://localhost:5001
    - Frontend UI: http://localhost:4173
 
-Environment variables for the backend are stored in `backend.node/.env`. Update this file if you need to target a different database host or change credentials. The Docker setup expects your MySQL instance to already be running and reachable at the host defined in that file.
+The container image now embeds a MariaDB instance that is automatically initialized with the `clinic` database schema and a dedicated application user. No external database service is required.
+
+### Default credentials
+
+The backend connects to the in-container database using the following defaults:
+
+| Variable      | Default        | Description                         |
+| ------------- | -------------- | ----------------------------------- |
+| `DB_HOST`     | `127.0.0.1`    | Internal database host              |
+| `DB_NAME`     | `clinic`       | Database name                       |
+| `DB_USER`     | `clinic_user`  | Database user created at start-up   |
+| `DB_PASSWORD` | `clinic_pass`  | Password for `clinic_user`          |
+
+Override these variables at container runtime if you need to supply different credentials.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure runtime directories exist
+mkdir -p /run/mysqld
+chown mysql:mysql /run/mysqld
+chown -R mysql:mysql /var/lib/mysql
+
+# Initialize MariaDB data directory if needed
+if [ ! -d /var/lib/mysql/mysql ]; then
+  echo "Initializing MariaDB data directory..."
+  mariadb-install-db --user=mysql --datadir=/var/lib/mysql >/dev/null
+fi
+
+# Start MariaDB in the background
+gosu mysql mysqld_safe --datadir=/var/lib/mysql --socket=/run/mysqld/mysqld.sock &
+MYSQL_PID=$!
+
+# Wait for MariaDB to accept connections
+TRIES=0
+until mariadb-admin ping --silent; do
+  TRIES=$((TRIES + 1))
+  if [ "$TRIES" -ge 30 ]; then
+    echo "MariaDB failed to start." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "MariaDB started."
+
+# Seed database and user if not already done
+if [ ! -f /var/lib/mysql/.db_initialized ]; then
+  echo "Configuring clinic database..."
+  mariadb <<'SQL'
+CREATE DATABASE IF NOT EXISTS clinic;
+CREATE USER IF NOT EXISTS 'clinic_user'@'%' IDENTIFIED BY 'clinic_pass';
+GRANT ALL PRIVILEGES ON clinic.* TO 'clinic_user'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+  if [ -f /app/backend.node/createtable.sql ]; then
+    echo "Applying schema from createtable.sql..."
+    mariadb -u"${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}" < /app/backend.node/createtable.sql || true
+  fi
+
+  touch /var/lib/mysql/.db_initialized
+fi
+
+# Start backend server
+node backend.node/server.js &
+NODE_PID=$!
+
+# Start frontend static server
+serve -s frontend/dist -l "${FRONTEND_PORT:-4173}" &
+SERVE_PID=$!
+
+# Relay signals
+trap 'kill $NODE_PID $SERVE_PID $MYSQL_PID 2>/dev/null || true' TERM INT
+
+wait $NODE_PID
+NODE_STATUS=$?
+wait $SERVE_PID
+SERVE_STATUS=$?
+EXIT_CODE=$NODE_STATUS
+if [ $SERVE_STATUS -ne 0 ] && [ $SERVE_STATUS -gt $EXIT_CODE ]; then
+  EXIT_CODE=$SERVE_STATUS
+fi
+
+# Ensure background processes terminate
+kill $MYSQL_PID >/dev/null 2>&1 || true
+kill $NODE_PID >/dev/null 2>&1 || true
+kill $SERVE_PID >/dev/null 2>&1 || true
+
+wait $MYSQL_PID >/dev/null 2>&1 || true
+wait $NODE_PID >/dev/null 2>&1 || true
+wait $SERVE_PID >/dev/null 2>&1 || true
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- install MariaDB and supporting dependencies in the application Docker image and expose default database environment variables
- add an entrypoint script that initializes the MariaDB data directory, seeds the clinic schema, and starts the backend plus frontend services
- document the embedded database and default credentials in the README for easier configuration

## Testing
- docker build -t finalproject:test . *(fails: docker: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0418a5f2083229e139f7fdfedb53c